### PR TITLE
refactor: MAIN内の関数をdefine, macroに分割、ログをユーザー側とsharedそれぞれに書き出すように変更

### DIFF
--- a/scripts/MAIN.py
+++ b/scripts/MAIN.py
@@ -1,19 +1,16 @@
-import importlib
-import sys
-import os
-import tkinter.filedialog as tkfd
-from tkinter import Tk
-import inputModule as inp
-import measurementManager as mm
-import utilityModule as util
-from importlib.util import spec_from_loader, module_from_spec
-from importlib.machinery import SourceFileLoader 
 import ctypes
-from utilityModule import GPyMException,printlog,inputlog
+import os
+import sys
+from logging import getLogger
+
+import measurementManager as mm
 import variables as vars
+from define import read_deffile
+from inputModule import ask_open_filename
+from macro import get_macro, get_macro_bunkatsu, get_macropath
+from utilityModule import setlog
 
-
-logger=util.mklogger(__name__)
+logger = getLogger(__name__)
 
 
 def main():
@@ -33,319 +30,101 @@ def main():
     measurementManager._measure_startを実行
 
     """
-    #sys.path.append(os.path.dirname(sys.executable))
+    # 定義ファイル読み取り
+    read_deffile()
 
-    
-    path_deffile=get_deffile()#定義ファイル取得
-    printlog("define file : "+os.path.basename(path_deffile))
+    macropath, _, macrodir = get_macropath()
 
-    datadir,macrodir_default,tempdir =read_deffile(path_deffile)#定義ファイル読み取り
+    macro, data_label = get_macro(macropath)
 
-    macropath,macroname,macrodir=get_macropath(macrodir_default)
+    mm._set_variables(
+        datadir=vars.DATADIR,
+        tempdir=vars.MACRODIR,
+        file_label=data_label,
+        shared_settings_dir=str(vars.SHARED_SETTINGSDIR),
+    )
 
-    macro,data_label=get_macro(macropath)
+    # カレントディレクトリを測定マクロ側に変更
+    os.chdir(macrodir)
 
+    # 測定開始
+    mm._measure_start(
+        start=macro.start,
+        update=macro.update,
+        end=macro.end,
+        on_command=macro.on_command,
+        bunkatsu=macro.bunkatsu,
+    )
 
-    mm._set_variables(datadir=datadir,tempdir=tempdir,file_label=data_label,shared_settings_dir=vars.SHERED_SETTINGSDIR)
-
-    os.chdir(macrodir)#カレントディレクトリを測定マクロ側に変更
-
-    mm._measure_start(start=macro.start,update=macro.update,end=macro.end,on_command=macro.on_command,bunkatsu=macro.bunkatsu)#測定開始
-    
-
-def get_deffile():
-    path_deffilepath=vars.SHARED_TEMPDIR+"\\deffilepath"#前回の定義ファルのパスが保存されているファイル
-    if not os.path.isfile(path_deffilepath):#deffilepathがなければ作る
-        with open(path_deffilepath,mode="w",encoding="utf-8") as f:
-            pass
-
-    with open(path_deffilepath,mode="r",encoding="utf-8") as f:#前回の定義ファイルのフォルダを開いて定義ファイル選択画面へ
-        predefpath=f.read()
-        predefdir=None
-        predeffilename=None
-        if os.path.isfile(predefpath):
-            predefdir,predeffilename=os.path.split(predefpath)
-        print("定義ファイル選択...")
-
-
-        tk = Tk()
-        typ = [('定義ファイル', '*.def')]
-        defpath=tkfd.askopenfilename(filetypes = typ,title="定義ファイルを選んでください",initialdir=predefdir,initialfile=predeffilename) #ファイルダイアログでファイルを取得
-        tk.destroy() #これとtk=Tk()がないと謎のウィンドウが残って邪魔になる
-
-    if os.path.isfile(defpath):
-        with open(path_deffilepath,mode="w",encoding="utf-8") as f:#今回の定義ファイルのパスを保存
-            f.write(defpath)
-
-    return defpath
-
-
-def read_deffile(path_deffile):#定義ファイルを読み込んで各フォルダのパスを取得
-    datadir=None
-    macrodir=None
-    tempdir=None
-
-    with open(path_deffile, "r", encoding=util.get_encode_type(path_deffile)) as f: #ファイルの読み込み
-        #ファイルの中身を1行ずつ見ていく
-        while True:
-            line=f.readline() #ファイルから1行取得
-            if line:
-                line = "".join(line.split()) #スペース･改行文字の削除
-                line=line.rstrip("\\") #パスの最後尾に"\"があれば削除
-                if "DATADIR=" in line:
-                    datadir=line[8:] #"DATADIR="の後ろの文字列を取得
-                if "TMPDIR=" in line:
-                    tempdir=line[7:]
-                if "MACRODIR=" in line:
-                    macrodir=line[9:]
-                    
-            else:#最後の行までいったらbreak
-                break
-
-        
-        
-        if datadir==None:
-            #最後まで見てDATADIRが無ければエラー表示
-            input("ERROR : 定義ファイルにDATADIRの定義がありません")
-            sys.exit()
-        else:
-
-            if ":" not in datadir:#相対パスなら定義ファイルからの絶対パスに変換
-                datadir=os.path.dirname(path_deffile)+"/"+datadir
-
-            if not os.path.isdir(datadir):#データフォルダが存在しなければエラー
-                input("定義ファイルERROR : "+datadir+"は定義ファイルに設定されていますが存在しません")
-                sys.exit()
-
-
-        if tempdir==None:
-            #最後まで見てTEMPDIRが無ければエラー表示
-            input("ERROR : 定義ファイルにTMPDIRの定義がありません")
-            sys.exit()
-        else:
-
-            if ":" not in tempdir:#相対パスなら定義ファイルからの絶対パスに変換
-                tempdir=os.path.dirname(path_deffile)+"/"+tempdir
-
-            if not os.path.isdir(tempdir):#TEMPフォルダが存在しなければエラー
-                input("定義ファイルERROR : "+tempdir+"は定義ファイルに設定されていますが存在しません")
-                sys.exit()
-
-
-        if macrodir==None:
-            print("warning:you can set MACRODIR in your define file")
-        else:
-            if ":" not in macrodir:#相対パスなら定義ファイルからの絶対パスに変換
-                macrodir=os.path.dirname(path_deffile)+"/"+macrodir
-
-            if not os.path.isdir(macrodir):#マクロフォルダが存在しなければ警告
-                print("定義ファイルWARING : "+macrodir+"は定義ファイルに設定されていますが存在しません")
-                macrodir=None
-
-        vars.DATADIR=datadir
-        vars.TEMPDIR=tempdir
-        vars.MACRODIR=macrodir
-
-        return datadir,macrodir,tempdir #MACRODIRは定義されてなくても通す
-
-
-def get_macropath(path_macrodir):
-    path_premacroname=vars.SHARED_TEMPDIR+"\\premacroname"#前回のマクロ名が保存されたファイルのパス
-    if not os.path.isfile(path_premacroname):
-        with open(path_premacroname,mode="w",encoding="utf-8") as f:
-            pass
-
-    with open(path_premacroname,mode="r",encoding="utf-8") as f:
-        premacroname=f.read()
-
-
-    tk = Tk()
-    print("マクロ選択...")
-    typ = [('pythonファイル','*.py *.gpym')] #gpymは勝手に作った拡張子
-    macropath=tkfd.askopenfilename(filetypes = typ,title="マクロを選択してください",initialdir=path_macrodir,initialfile=premacroname) #マクロ選択
-    tk.destroy() #これとtk=Tk()がないと謎のウィンドウが残って邪魔になる
-
-
-    macrodir,macroname=os.path.split(macropath)#マクロのパスをフォルダとファイル名に分割
-
-    with open(path_premacroname,mode="w",encoding="utf-8") as f:
-        f.write(macroname)
-
-
-    printlog("macro : "+macroname)
-    macroname=os.path.splitext(macroname)[0]#ファイル名から拡張子をとる
-    return macropath,macroname,macrodir
-
-def get_macro(macropath):#パスから各種関数を読み込み
-
-    macroname=os.path.splitext(os.path.split(macropath)[1])[0]
-    #importlibを使って動的にpythonファイルを読み込む
-    spec = spec_from_loader(macroname, SourceFileLoader(macroname,macropath))
-    target = module_from_spec(spec)
-    spec.loader.exec_module(target)
-
-    #測定マクロに必要な関数と引数が含まれているか確認
-    UNDIFINE_ERROR=False
-    UNDIFINE_WARNING=""
-    if not hasattr(target, 'start'):
-        target.start=None
-        UNDIFINE_WARNING+="start, "
-    elif target.start.__code__.co_argcount!=0:
-        logger.error(target.__name__+".startには引数を設定してはいけません")
-        UNDIFINE_ERROR=True
-
-    if not hasattr(target, 'update'):
-        logger.error(target.__name__+".pyの中でupdateを定義する必要があります")
-        UNDIFINE_ERROR=True
-    elif target.update.__code__.co_argcount!=0:
-        logger.error(target.__name__+".updateには引数を設定してはいけません")
-        UNDIFINE_ERROR=True
-
-    if not hasattr(target, 'end'):
-        target.end=None
-        UNDIFINE_WARNING+="end, "
-    elif target.end.__code__.co_argcount!=0:
-        logger.error(target.__name__+".endには引数を設定してはいけません")
-        UNDIFINE_ERROR=True
-
-    if not hasattr(target, 'on_command'):
-        target.on_command=None
-        UNDIFINE_WARNING+="on_command, "
-    elif target.on_command.__code__.co_argcount!=1:
-        logger.error(target.__name__+".on_commandには引数を設定してはいけません")
-        UNDIFINE_ERROR=True
-
-    if not hasattr(target, 'bunkatsu'):
-        target.bunkatsu=None
-        UNDIFINE_WARNING+="bunkatsu, "
-    elif target.bunkatsu.__code__.co_argcount!=1:
-        logger.error(target.__name__+".bunkatsuには引数を設定してはいけません")
-        UNDIFINE_ERROR=True
-               
-    if UNDIFINE_WARNING !="":
-        UNDIFINE_WARNING=UNDIFINE_WARNING[:-2]
-        printlog("UNDEFINED FUNCTION : "+UNDIFINE_WARNING)
-
-    
-    if issubclass(target.Data,tuple):
-        data_label=""
-        count=1
-        for s in target.Data._fields:
-            data_label+="["+str(count)+"]"+s+", "
-            count+=1
-        data_label=data_label[:-2]
-    else:
-        logger.error("Dataをnamedtupleで定義してください")
-        UNDIFINE_ERROR=True
-
-    if UNDIFINE_ERROR:
-        input("エラーのため終了します...")
-        sys.exit()
-
-    return target,data_label
 
 def bunkatsu_only():
-
-    tk = Tk()
     print("分割マクロ選択...")
-    typ = [('pythonファイル','*.py *.gpym')] 
-    macroPath=tkfd.askopenfilename(filetypes = typ,title="分割マクロを選択してください") #ファイルダイアログでファイルを取得 
+    macroPath = ask_open_filename(
+        filetypes=[("pythonファイル", "*.py *.gpym")], title="分割マクロを選択してください"
+    )
 
-    macrodir,macroname=os.path.split(macroPath)
-    macroname=os.path.splitext(macroname)[0]
-    os.chdir(macrodir)
-    print("macro : "+macroname)
+    os.chdir(str(macroPath.parent))
+    print(f"macro: {macroPath.stem}")
 
-
-    def hoge(address):
+    def noop(address):
         return None
+
     import GPIBModule
-    GPIBModule.get_instrument=hoge#GPIBモジュールの関数を書き換えてGPIBがつながって無くてもエラーが出ないようにする
-    print("INFO : you can't use GPIB.get_instrument in GPyM_bunkatsu")
-    print("INFO : you can't use most of measurementManager's methods in GPyM_bunkatsu")
 
+    # GPIBモジュールの関数を書き換えてGPIBがつながって無くてもエラーが出ないようにする
+    GPIBModule.get_instrument = noop
+    logger.info("you can't use GPIB.get_instrument in GPyM_bunkatsu")
+    logger.info("you can't use most of measurementManager's methods in GPyM_bunkatsu")
 
-    #bunkatsufunc=get_bunkatsu_func(macroPath) #マクロからbunkatsu関数部分だけを抜き出し
-     
-    #importlibを使って動的にpythonファイルを読み込む
-    spec = spec_from_loader(macroname, SourceFileLoader(macroname,macroPath))
-    target = module_from_spec(spec)
-    spec.loader.exec_module(target)
-       
-
-    if not hasattr(target, 'bunkatsu'):
-        raise util.create_error(target.__name__+".pyにはbunkatsu関数を定義する必要があります",logger)
-    elif target.bunkatsu.__code__.co_argcount!=1:
-        raise util.create_error(target.__name__+".bunkatsuには1つの引数が必要です",logger)
-
+    target = get_macro_bunkatsu(macroPath)
 
     print("分割ファイル選択...")
-    typ = [('データファイル','*.txt *dat')] 
-    filePath=tkfd.askopenfilename(filetypes = typ,title="分割するファイルを選択してください") #ファイルダイアログでファイルを取得
-    tk.destroy() #これとtk=Tk()がないと謎のウィンドウが残って邪魔になる
+    filePath = ask_open_filename(
+        filetypes=[("データファイル", "*.txt *dat")], title="分割するファイルを選択してください"
+    )
 
-    
-    mm._set_variables(datadir=None,tempdir=None,file_label=None,shared_settings_dir=vars.SHERED_SETTINGSDIR)
+    mm._set_variables(
+        datadir=None,
+        tempdir=None,
+        file_label=None,
+        shared_settings_dir=vars.SHARED_SETTINGSDIR,
+    )
     target.bunkatsu(filePath)
     input()
-    
 
 
-def setting():#変数のセット
-    filedir=os.getcwd()
-    vars.GPYM_HOMEDIR=filedir
-    if not os.path.isdir("temp"):#TEMPDIRが無ければつくる
-        os.mkdir("temp")
-    vars.SHARED_TEMPDIR=filedir+"\\temp"
+def setting():
+    """変数のセット"""
+    setlog()
 
-    if not os.path.isdir("shered_settings"):#SHERED_SETTINGSが無ければつくる
-        os.mkdir("shered_settings")
-    vars.SHERED_SETTINGSDIR=filedir+"\\shered_settings"
-
-
-    if not os.path.isdir("log"):
-        os.mkdir("log")
-    vars.SHARED_LOGDIR=filedir+"\\log"
-
-    vars.SHARED_SCRIPTSDIR=filedir+"\\scripts"
-
-    util.set_LOG(vars.SHARED_TEMPDIR+"\\LOG.txt")#ログをセット
-    util.setlog()#こっちに移行したい
-
-    #簡易編集モードをOFFにするためのおまじない
+    # 簡易編集モードをOFFにするためのおまじない
     kernel32 = ctypes.windll.kernel32
-    mode=0xFDB7 #簡易編集モードとENABLE_WINDOW_INPUT と ENABLE_VIRTUAL_TERMINAL_INPUT をOFFに
+    # 簡易編集モードとENABLE_WINDOW_INPUT と ENABLE_VIRTUAL_TERMINAL_INPUT をOFFに
+    mode = 0xFDB7
     kernel32.SetConsoleMode(kernel32.GetStdHandle(-10), mode)
 
 
-if __name__=="__main__":
-
+if __name__ == "__main__":
     setting()
 
+    mode = ""
     args = sys.argv
-    if len(args)==1:
-        mode=input("mode is > ")
-    else:
-        mode=args[1]
+    if len(args) > 1:
+        mode = args[1].upper()
+
+    while True:
+        if mode in ["MEAS", "BUNKATSU"]:
+            break
+        mode = input("mode is > ").upper()
+
     try:
-        
-        if mode=="MEAS":
+        if mode == "MEAS":
             main()
-        elif mode=="BUNKATSU":
-            bunkatsu_only()
         else:
-            input("コマンドが違います")
-            raise Exception()
+            bunkatsu_only()
 
     except Exception as e:
-        util.output_ErrorLog(vars.SHARED_TEMPDIR+"\\ERRORLOG.txt",e)
-        import traceback
+        logger.exception(e)
 
-        if type(e) is not GPyMException:#自分で設定したエラー以外はコンソールウィンドウにエラーログを表示
-            traceback.print_exc()#エラー表示
-            input("__Error__")#コンソールウィンドウが落ちないように入力待ちを入れる
-    else:
-        util.cut_LOG()
-    
-
-    
+        # コンソールウィンドウが落ちないように入力待ちを入れる
+        input("__Error__")

--- a/scripts/define.py
+++ b/scripts/define.py
@@ -1,0 +1,91 @@
+import os
+from logging import getLogger
+from pathlib import Path
+
+import variables as vars
+from inputModule import ask_open_filename
+from utilityModule import GPyMException, get_encode_type
+
+logger = getLogger(__name__)
+
+
+def get_deffile():
+    # 前回の定義ファルのパスが保存されているファイル
+    path_deffilepath = vars.SHARED_TEMPDIR / "deffilepath"
+    path_deffilepath.touch()
+
+    # 前回の定義ファイルのフォルダを開いて定義ファイル選択画面へ
+    predefdir = None
+    predeffilename = None
+    predefpath = Path(path_deffilepath.read_text())
+    if predefpath.is_file():
+        predefdir = str(predefpath.parent)
+        predeffilename = predefpath.name
+
+    print("定義ファイル選択...")
+    defpath = ask_open_filename(
+        filetypes=[("定義ファイル", "*.def")],
+        title="定義ファイルを選んでください",
+        initialdir=predefdir,
+        initialfile=predeffilename,
+    )
+
+    if defpath.is_file():
+        # 今回の定義ファイルのパスを保存
+        path_deffilepath.write_text(str(defpath))
+
+    return defpath
+
+
+def read_deffile():
+    """定義ファイルを読み込んで各フォルダのパスを取得"""
+    path_deffile = get_deffile()
+    logger.info(f"define file: {path_deffile.stem}")
+
+    datadir = None
+    macrodir = None
+    tempdir = None
+
+    with path_deffile.open(mode="r", encoding=get_encode_type(path_deffile)) as f:
+        # ファイルの中身を1行ずつ見ていく
+        for l in f:
+            # スペース･改行文字の削除
+            l = "".join(l.split())
+            if l.startswith("DATADIR="):
+                # "DATADIR="の後ろの文字列を取得
+                datadir = Path(l[8:])
+            elif l.startswith("TMPDIR="):
+                tempdir = Path(l[7:])
+            elif l.startswith("MACRODIR="):
+                macrodir = Path(l[9:])
+
+    # 最後まで見てDATADIRが無ければエラー表示
+    if datadir == None:
+        raise GPyMException("定義ファイルにDATADIRの定義がありません")
+    # 相対パスなら定義ファイルからの絶対パスに変換
+    if not datadir.is_absolute():
+        datadir = path_deffile / datadir
+    # データフォルダが存在しなければエラー
+    if not datadir.is_dir():
+        raise GPyMException(f"{datadir}は定義ファイルに設定されていますが存在しません")
+
+    if tempdir == None:
+        raise GPyMException("定義ファイルにTMPDIRの定義がありません")
+    if not tempdir.is_absolute():
+        tempdir = path_deffile / tempdir
+    if not tempdir.is_dir():
+        raise GPyMException(f"{tempdir}は定義ファイルに設定されていますが存在しません")
+
+    if macrodir == None:
+        logger.warning("you can set MACRODIR in your define file")
+    else:
+        if not macrodir.is_absolute():
+            macrodir = path_deffile / macrodir
+        if not macrodir.is_dir():
+            logger.warning(f"{macrodir}は定義ファイルに設定されていますが存在しません")
+            macrodir = None
+
+    # TODO (sakakibara): Use pathlib
+    vars.DATADIR = str(datadir)
+    vars.TEMPDIR = str(tempdir)
+    vars.MACRODIR = str(macrodir)

--- a/scripts/inputModule.py
+++ b/scripts/inputModule.py
@@ -1,10 +1,13 @@
 import datetime
-import tkinter.filedialog as tkfd
 import os
-import utilityModule as util
-from tkinter import Tk
 import sys
-from utilityModule import printlog,inputlog
+import tkinter.filedialog as tkfd
+from pathlib import Path
+from tkinter import Tk
+
+import utilityModule as util
+from utilityModule import inputlog, printlog
+
 
 def get_filename(text="file name is > "):
     """
@@ -16,40 +19,46 @@ def get_filename(text="file name is > "):
         出力ファイル名(入力した文字列に日時を追加したものを返す)
     """
 
-    ngwords=["\\","/","?",'"',"<",">","|",":","*"]#ファイルに使えない文字
-    wordok=False
+    ngwords = ["\\", "/", "?", '"', "<", ">", "|", ":", "*"]  # ファイルに使えない文字
+    wordok = False
     while not wordok:
 
-        filename=inputlog(text)
+        filename = inputlog(text)
         for ng in ngwords:
             if ng in filename:
                 printlog("WARNING : 以下の文字列はファイル名に使えません. 入力し直してください")
                 for w in ngwords:
-                    print(w,end="")
+                    print(w, end="")
                 print("")
                 break
         else:
-            wordok=True
+            wordok = True
 
-    #半角スペース,全角スペース,タブは削除
-    filename=filename.replace(" ","")
-    filename=filename.replace("\u3000","")
-    filename=filename.replace("\t","")
+    # 半角スペース,全角スペース,タブは削除
+    filename = filename.replace(" ", "")
+    filename = filename.replace("\u3000", "")
+    filename = filename.replace("\t", "")
+
+    dt_now = datetime.datetime.now()  # 日時取得
+
+    # 日時をゼロ埋めしたりしてからファイル名の先頭につける
+    year = str(dt_now.year)
+
+    datelabel = (
+        year[2]
+        + year[3]
+        + str(dt_now.month).zfill(2)
+        + str(dt_now.day).zfill(2)
+        + "-"
+        + str(dt_now.hour).zfill(2)
+        + str(dt_now.minute).zfill(2)
+        + str(dt_now.second).zfill(2)
+    )
+    fullfilename = datelabel + "_" + filename
+    return fullfilename, datelabel, filename
 
 
-    
-
-    dt_now = datetime.datetime.now() #日時取得
-
-    #日時をゼロ埋めしたりしてからファイル名の先頭につける
-    year=str(dt_now.year)
-
-    datelabel=year[2]+year[3]+str(dt_now.month).zfill(2)+str(dt_now.day).zfill(2)+"-"+str(dt_now.hour).zfill(2)+str(dt_now.minute).zfill(2)+str(dt_now.second).zfill(2)
-    fullfilename=datelabel+"_"+filename
-    return fullfilename,datelabel,filename
-
-
-def read_defdir(dirpath=None,filename=None):
+def read_defdir(dirpath=None, filename=None):
 
     """
     定義ファイルからデータの保存先ディレクトリを取得
@@ -60,83 +69,91 @@ def read_defdir(dirpath=None,filename=None):
         データの保存先ディレクトリ
     """
 
-    
-
-    
     tk = Tk()
-    typ = [('定義ファイル', '*.def')]
-    defpath=tkfd.askopenfilename(filetypes = typ,title="定義ファイルを選んでください",initialdir=dirpath,initialfile=filename) #ファイルダイアログでファイルを取得
-    fileobj = open(defpath, "r", encoding=util.get_encode_type(defpath)) #ファイルの読み込み
+    typ = [("定義ファイル", "*.def")]
+    defpath = tkfd.askopenfilename(
+        filetypes=typ, title="定義ファイルを選んでください", initialdir=dirpath, initialfile=filename
+    )  # ファイルダイアログでファイルを取得
+    fileobj = open(defpath, "r", encoding=util.get_encode_type(defpath))  # ファイルの読み込み
 
-    tk.destroy() #これとtk=Tk()がないと謎のウィンドウが残って邪魔になる
+    tk.destroy()  # これとtk=Tk()がないと謎のウィンドウが残って邪魔になる
 
-    printlog("define file : "+os.path.basename(defpath))
+    printlog("define file : " + os.path.basename(defpath))
 
-    datadir=None
-    macrodir=None
-    tempdir=None
-    #ファイルの中身を1行ずつ見ていく
+    datadir = None
+    macrodir = None
+    tempdir = None
+    # ファイルの中身を1行ずつ見ていく
     while True:
-        line=fileobj.readline() #ファイルから1行取得
+        line = fileobj.readline()  # ファイルから1行取得
         if line:
-            line = "".join(line.split()) #スペース･改行文字の削除
-            line=line.rstrip("\\") #パスの最後尾に"\"があれば削除
+            line = "".join(line.split())  # スペース･改行文字の削除
+            line = line.rstrip("\\")  # パスの最後尾に"\"があれば削除
             if "DATADIR=" in line:
-                datadir=line[8:] #"DATADIR="の後ろの文字列を取得
+                datadir = line[8:]  # "DATADIR="の後ろの文字列を取得
             if "TMPDIR=" in line:
-                tempdir=line[7:]
+                tempdir = line[7:]
             if "MACRODIR=" in line:
-                macrodir=line[9:]
-                 
-        else:#最後の行までいったらbreak
+                macrodir = line[9:]
+
+        else:  # 最後の行までいったらbreak
             break
 
-    
-    
-    if datadir==None:
-        #最後まで見てDATADIRが無ければエラー表示
+    if datadir == None:
+        # 最後まで見てDATADIRが無ければエラー表示
         input("ERROR : 定義ファイルにDATADIRの定義がありません")
         sys.exit()
     else:
 
-        if ":" not in datadir:#相対パスなら定義ファイルからの絶対パスに変換
-            datadir=os.path.dirname(defpath)+"/"+datadir
+        if ":" not in datadir:  # 相対パスなら定義ファイルからの絶対パスに変換
+            datadir = os.path.dirname(defpath) + "/" + datadir
 
-        if not os.path.isdir(datadir):#データフォルダが存在しなければエラー
-            input("定義ファイルERROR : "+datadir+"は存在しないフォルダですがDATADIRとして設定されています")
+        if not os.path.isdir(datadir):  # データフォルダが存在しなければエラー
+            input("定義ファイルERROR : " + datadir + "は存在しないフォルダですがDATADIRとして設定されています")
             sys.exit()
 
-
-    if tempdir==None:
-        #最後まで見てTEMPDIRが無ければエラー表示
+    if tempdir == None:
+        # 最後まで見てTEMPDIRが無ければエラー表示
         input("ERROR : 定義ファイルにTMPDIRの定義がありません")
         sys.exit()
     else:
 
-        if ":" not in tempdir:#相対パスなら定義ファイルからの絶対パスに変換
-            tempdir=os.path.dirname(defpath)+"/"+tempdir
+        if ":" not in tempdir:  # 相対パスなら定義ファイルからの絶対パスに変換
+            tempdir = os.path.dirname(defpath) + "/" + tempdir
 
-        if not os.path.isdir(tempdir):#データフォルダが存在しなければエラー
-            input("定義ファイルERROR : "+tempdir+"は存在しないフォルダですがTMPDIRとして設定されています")
+        if not os.path.isdir(tempdir):  # データフォルダが存在しなければエラー
+            input("定義ファイルERROR : " + tempdir + "は存在しないフォルダですがTMPDIRとして設定されています")
             sys.exit()
 
-
-    if macrodir==None:
+    if macrodir == None:
         print("warning:you can set MACRODIR in your define file")
     else:
-        if ":" not in macrodir:#相対パスなら定義ファイルからの絶対パスに変換
-            macrodir=os.path.dirname(defpath)+"/"+macrodir
+        if ":" not in macrodir:  # 相対パスなら定義ファイルからの絶対パスに変換
+            macrodir = os.path.dirname(defpath) + "/" + macrodir
 
-        if not os.path.isdir(macrodir):#マクロフォルダが存在しなければ警告
-            print("定義ファイルWARING : "+macrodir+"は存在しないフォルダですがMACRODIRとして設定されています")
-            macrodir=None
+        if not os.path.isdir(macrodir):  # マクロフォルダが存在しなければ警告
+            print("定義ファイルWARING : " + macrodir + "は存在しないフォルダですがMACRODIRとして設定されています")
+            macrodir = None
 
-
-
-    return defpath,datadir,macrodir,tempdir #MACRODIRは定義されてなくても通す
+    return defpath, datadir, macrodir, tempdir  # MACRODIRは定義されてなくても通す
 
 
+def ask_open_filename(filetypes=None, title=None, initialdir=None, initialfile=None):
+    tk = Tk()
+
+    # ファイルダイアログでファイルを取得
+    path = tkfd.askopenfilename(
+        filetypes=filetypes,
+        title=title,
+        initialdir=initialdir,
+        initialfile=initialfile,
+    )
+
+    # これとtk=Tk()がないと謎のウィンドウが残って邪魔になる
+    tk.destroy()
+
+    return Path(path).absolute()
 
 
-if __name__=="__main__":
+if __name__ == "__main__":
     print(input_num("input>"))

--- a/scripts/log_config.json
+++ b/scripts/log_config.json
@@ -13,12 +13,20 @@
       "formatter": "default",
       "stream": "ext://sys.stdout"
     },
-    "fileHandler": {
+    "sharedFileHandler": {
       "class": "logging.FileHandler",
-      "level": "INFO",
+      "level": "WARNING",
       "formatter": "default",
       "filename": "",
       "encoding": "utf-8"
+    },
+    "localFileHandler": {
+      "class": "logging.handlers.RotatingFileHandler",
+      "level": "INFO",
+      "formatter": "default",
+      "filename": "",
+      "encoding": "utf-8",
+      "maxBytes": 102400
     }
   },
   "root": {

--- a/scripts/macro.py
+++ b/scripts/macro.py
@@ -1,0 +1,120 @@
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+from logging import getLogger
+from pathlib import Path
+
+import variables as vars
+from inputModule import ask_open_filename
+from utilityModule import GPyMException
+
+logger = getLogger(__name__)
+
+
+class MacroError(GPyMException):
+    pass
+
+
+def get_macropath():
+    # 前回のマクロ名が保存されたファイルのパス
+    path_premacroname = vars.SHARED_TEMPDIR / "premacroname"
+    path_premacroname.touch()
+
+    premacroname = path_premacroname.read_text(encoding="utf-8")
+
+    # gpymは勝手に作った拡張子
+    macropath = ask_open_filename(
+        filetypes=[("pythonファイル", "*.py *.gpym")],
+        title="マクロを選択してください",
+        initialdir=vars.MACRODIR,
+        initialfile=premacroname,
+    )
+
+    macrodir = str(macropath.parent)
+    macroname = macropath.stem
+
+    path_premacroname.write_text(macropath.name, encoding="utf-8")
+    logger.info(f"macro: {macropath.name}")
+
+    return macropath, macroname, macrodir
+
+
+def get_macro(macropath: Path):
+    """パスから各種関数を読み込み"""
+    macroname = macropath.stem
+
+    # importlibを使って動的にpythonファイルを読み込む
+    spec = spec_from_loader(macroname, SourceFileLoader(macroname, macropath))
+    target = module_from_spec(spec)
+    spec.loader.exec_module(target)
+
+    # 測定マクロに必要な関数と引数が含まれているか確認
+    UNDIFINE_ERROR = False
+    UNDIFINE_WARNING = []
+    if not hasattr(target, "start"):
+        target.start = None
+        UNDIFINE_WARNING.append("start")
+    elif target.start.__code__.co_argcount != 0:
+        logger.error(target.__name__ + ".startには引数を設定してはいけません")
+        UNDIFINE_ERROR = True
+
+    if not hasattr(target, "update"):
+        logger.error(target.__name__ + ".pyの中でupdateを定義する必要があります")
+        UNDIFINE_ERROR = True
+    elif target.update.__code__.co_argcount != 0:
+        logger.error(target.__name__ + ".updateには引数を設定してはいけません")
+        UNDIFINE_ERROR = True
+
+    if not hasattr(target, "end"):
+        target.end = None
+        UNDIFINE_WARNING.append("end")
+    elif target.end.__code__.co_argcount != 0:
+        logger.error(target.__name__ + ".endには引数を設定してはいけません")
+        UNDIFINE_ERROR = True
+
+    if not hasattr(target, "on_command"):
+        target.on_command = None
+        UNDIFINE_WARNING.append("on_command")
+    elif target.on_command.__code__.co_argcount != 1:
+        logger.error(target.__name__ + ".on_commandには引数を設定してはいけません")
+        UNDIFINE_ERROR = True
+
+    if not hasattr(target, "bunkatsu"):
+        target.bunkatsu = None
+        UNDIFINE_WARNING.append("bunkatsu")
+    elif target.bunkatsu.__code__.co_argcount != 1:
+        logger.error(target.__name__ + ".bunkatsuには引数を設定してはいけません")
+        UNDIFINE_ERROR = True
+
+    if len(UNDIFINE_WARNING) > 0:
+        logger.info("UNDEFINED FUNCTION: " + ", ".join(UNDIFINE_WARNING))
+
+    if issubclass(target.Data, tuple):
+        data = []
+        count = 1
+        for s in target.Data._fields:
+            data.append(f"[{count}]{s}")
+            count += 1
+        data_label = ", ".join(data)
+    else:
+        data_label = ""
+        logger.error("Dataをnamedtupleで定義してください")
+        UNDIFINE_ERROR = True
+
+    if UNDIFINE_ERROR:
+        raise MacroError("macroの関数定義が正しくありません")
+
+    return target, data_label
+
+
+def get_macro_bunkatsu(macroPath: Path):
+    macroname = macroPath.stem
+    spec = spec_from_loader(macroname, SourceFileLoader(macroname, macroPath))
+    target = module_from_spec(spec)
+    spec.loader.exec_module(target)
+
+    if not hasattr(target, "bunkatsu"):
+        raise MacroError(f"{target.__name__}.pyにはbunkatsu関数を定義する必要があります")
+    elif target.bunkatsu.__code__.co_argcount != 1:
+        raise MacroError(f"{target.__name__}.bunkatsuには1つの引数が必要です")
+
+    return target

--- a/scripts/variables.py
+++ b/scripts/variables.py
@@ -1,9 +1,27 @@
-TEMPDIR=None#ユーザーTEMPフォルダーのパス
-DATADIR=None#ユーザーDATAフォルダーのパス
-MACRODIR=None#ユーザーMACROフォルダーのパス
+from pathlib import Path
 
-SHARED_TEMPDIR=None#共有TEMPフォルダーのパス
-SHERED_SETTINGSDIR=None#共有設定フォルダのパス
-SHARED_SCRIPTSDIR=None#scriptsフォルダーのパス
-SHARED_LOGDIR=None#logフォルダーのパス
-GPYM_HOMEDIR=None#GPyMフォルダーのパス
+TEMPDIR = None  # ユーザーTEMPフォルダーのパス
+DATADIR = None  # ユーザーDATAフォルダーのパス
+MACRODIR = None  # ユーザーMACROフォルダーのパス
+
+
+# GPyMフォルダーのパス
+GPYM_HOMEDIR = Path.cwd()
+
+# 共有TEMPフォルダーのパス
+SHARED_TEMPDIR = GPYM_HOMEDIR / "temp"
+if not SHARED_TEMPDIR.is_dir():
+    SHARED_TEMPDIR.mkdir()
+
+# 共有設定フォルダのパス
+SHARED_SETTINGSDIR = GPYM_HOMEDIR / "shared_settings"
+if not SHARED_SETTINGSDIR.is_dir():
+    SHARED_SETTINGSDIR.mkdir()
+
+# scriptsフォルダーのパス
+SHARED_SCRIPTSDIR = GPYM_HOMEDIR / "scripts"
+
+# logフォルダーのパス
+SHARED_LOGDIR = GPYM_HOMEDIR / "log"
+if not SHARED_LOGDIR.is_dir():
+    SHARED_LOGDIR.mkdir()


### PR DESCRIPTION
Issue: #2

- MAIN.pyの関数を一部define.py、macro.pyに分割
- `set_LOG()`をやめ、ログをユーザー側とshared側それぞれに書き出すように変更
- variables.pyの初期化をvariables.pyで行うように変更
- 不正なモードだった場合にエラーにせず聞き返すように変更
- 全体的にpathlibを使うように変更